### PR TITLE
[US01-30] Validar campos de senha e CEP

### DIFF
--- a/src/pages/SignUp/Address/index.tsx
+++ b/src/pages/SignUp/Address/index.tsx
@@ -47,6 +47,8 @@ function Address({
         id="cep"
         label={"CEP"}
         value={cep}
+        pattern="^\d{8}$"
+        title="O campo deve ter 8 caracteres (apenas números)."
         onChange={(e) => setCep(e.target.value)}
         onBlur={handleCep}
       />

--- a/src/pages/SignUp/Informations/index.tsx
+++ b/src/pages/SignUp/Informations/index.tsx
@@ -47,6 +47,8 @@ function Informations({
         type="password"
         label="Senha"
         value={password}
+        pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$"
+        title="Sua senha deve ter no mínimo 8 caracteres, uma letra maíuscula, uma letra minúscula, um número e um caractere especial."
         onChange={(e) => setPassword(e.target.value)}
       />
       <Input
@@ -55,6 +57,8 @@ function Informations({
         type="password"
         label="Confirme sua senha"
         value={confirmPassword}
+        pattern={password}
+        title="As senhas digitadas devem ser iguais."
         onChange={(e) => setConfirmPassword(e.target.value)}
       />
       <Button type="submit">Avançar</Button>


### PR DESCRIPTION
## O que foi feito
Realizada a validação dos campos de senha e de CEP usando Regex:

- Senha de no mínimo 8 caracteres, contendo pelo menos uma letra maiúscula, uma letra minúscula, um número e um caractere especial. 
- Validado se o campo de senha e de confirmação de senha são iguais;
- Validado se o campo de CEP contém 8 caracteres numéricos.