### PR TITLE
[US01-32] Validar o campo "Outro" no cadastro de instituição

### DIFF
--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -71,7 +71,7 @@ function SignUp(): JSX.Element {
       cep,
       state,
       city,
-      cause,
+      cause: cause === "Outro" ? customCause : cause,
       description,
     } as { [key: string]: any };
     const formData = new FormData();

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -72,8 +72,12 @@ function SignUp(): JSX.Element {
       state,
       city,
       cause: cause === "Outro" ? customCause : cause,
-      description,
     } as { [key: string]: any };
+
+    if (description !== "") {
+      user.description = description;
+    }
+
     const formData = new FormData();
     Object.keys(user).forEach((key) => {
       formData.append(key, user[key]);


### PR DESCRIPTION
## O que foi feito
Corrigido o problema onde o campo "outro" não era enviado. Também foi ajustado para que o campo `description` seja enviado apenas se for preenchido.

Closes #7 