### PR TITLE
[US01-33] Cadastro de usuário não valida senha quando tem o caractere '$'

### DIFF
--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -3,12 +3,11 @@ import LogoSvg from "../../assets/logo.svg";
 import { Button } from "../../components/Button";
 import { Input } from "../../components/Input";
 import { Divider } from "../../components/Divider";
-import { Form, Link } from "../../styles/global";
+import { ErrorMessage, Form, Link } from "../../styles/global";
 import {
   BottomArea,
   CustomPaper,
   CustomText,
-  ErrorMessage,
   FormContainer,
   ImageContainer,
   LoginImage,

--- a/src/pages/Login/styles.ts
+++ b/src/pages/Login/styles.ts
@@ -63,21 +63,4 @@ const BottomArea = styled.div`
   }
 `;
 
-const ErrorMessage = styled.p`
-  color: ${(props) => props.theme.colors.ERROR};
-  align-self: flex-start;
-  margin: 0;
-  font-size: 14px;
-  font-weight: 500;
-`;
-
-export {
-  CustomPaper,
-  ImageContainer,
-  LoginImage,
-  FormContainer,
-  Logo,
-  CustomText,
-  BottomArea,
-  ErrorMessage,
-};
+export { CustomPaper, ImageContainer, LoginImage, FormContainer, Logo, CustomText, BottomArea };

--- a/src/pages/SignUp/Informations/index.tsx
+++ b/src/pages/SignUp/Informations/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from "../../../components/Button";
 import { Input } from "../../../components/Input";
+import { ErrorMessage } from "../../../styles/global";
 
 interface InformationProps {
   type: string;
@@ -11,6 +12,7 @@ interface InformationProps {
   setPassword: React.Dispatch<React.SetStateAction<string>>;
   confirmPassword: string;
   setConfirmPassword: React.Dispatch<React.SetStateAction<string>>;
+  passwordError: string;
 }
 
 function Informations({
@@ -23,6 +25,7 @@ function Informations({
   setPassword,
   confirmPassword,
   setConfirmPassword,
+  passwordError,
 }: InformationProps): JSX.Element {
   return (
     <>
@@ -57,10 +60,10 @@ function Informations({
         type="password"
         label="Confirme sua senha"
         value={confirmPassword}
-        pattern={password}
-        title="As senhas digitadas devem ser iguais."
         onChange={(e) => setConfirmPassword(e.target.value)}
       />
+      {passwordError && <ErrorMessage>{passwordError}</ErrorMessage>}
+
       <Button type="submit">Avançar</Button>
     </>
   );

--- a/src/pages/SignUp/Informations/index.tsx
+++ b/src/pages/SignUp/Informations/index.tsx
@@ -50,7 +50,7 @@ function Informations({
         type="password"
         label="Senha"
         value={password}
-        pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$"
+        pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[#?!@$%^&*])[A-Za-z\d#?!@$%^&*]{8,}$"
         title="Sua senha deve ter no mínimo 8 caracteres, uma letra maíuscula, uma letra minúscula, um número e um caractere especial."
         onChange={(e) => setPassword(e.target.value)}
       />

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -24,6 +24,7 @@ function SignUp(): JSX.Element {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
   const [message, setMessage] = useState<string>();
+  const [passwordError, setPasswordError] = useState<string>("");
 
   const [name, setName] = useState<string>("");
   const [email, setEmail] = useState<string>("");
@@ -57,10 +58,15 @@ function SignUp(): JSX.Element {
 
   function nextStep(event: BaseSyntheticEvent) {
     event.preventDefault();
-    setCurrentStep(currentStep + 1);
+    if (password === confirmPassword) {
+      setPasswordError("");
+      setCurrentStep(currentStep + 1);
 
-    if (currentStep === totalSteps) {
-      handleSignUp();
+      if (currentStep === totalSteps) {
+        handleSignUp();
+      }
+    } else {
+      setPasswordError("As senhas digitadas devem ser iguais.");
     }
   }
 
@@ -172,6 +178,7 @@ function SignUp(): JSX.Element {
                   setPassword={setPassword}
                   confirmPassword={confirmPassword}
                   setConfirmPassword={setConfirmPassword}
+                  passwordError={passwordError}
                 />
               )}
 

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -86,4 +86,12 @@ const Link = styled(RouterLink)`
   font-weight: 700;
 `;
 
-export { Paper, Title, Text, Strong, Label, Screen, Form, Link };
+const ErrorMessage = styled.p`
+  color: ${(props) => props.theme.colors.ERROR};
+  align-self: flex-start;
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+export { Paper, Title, Text, Strong, Label, Screen, Form, Link, ErrorMessage };


### PR DESCRIPTION
## O que foi feito
- Realizado o ajuste na confirmação de senha;
- Adicionados novos caracteres especiais a regex;
- Estilo de mensagem de erro movido para o arquivo de estilo global.