### PR TITLE
[MELHORIA-96] Impedir que uma ONG  acesse a página de edição de PIX/Redes sociais de outra ONG

### DIFF
--- a/src/pages/Organizations/Pix/index.tsx
+++ b/src/pages/Organizations/Pix/index.tsx
@@ -15,6 +15,7 @@ import { Message } from "../../../components/Message";
 import { handleKeyTypeChange } from "../../../utils/handleKeyTypeChange";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../../../contexts/AuthContext";
+import { OrganizationInterface } from "../../../services/users";
 
 export const keyTypeLabels: { [key in PixKeyType]: string } = {
   [PixKeyType.Email]: "E-mail",
@@ -30,6 +31,8 @@ function Pix(): JSX.Element {
   const [key, setKey] = useState<string>("");
   const [name, setName] = useState<string>("");
   const [bank, setBank] = useState<string>("");
+
+  const [owner, setOwner] = useState<OrganizationInterface>();
 
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
@@ -50,6 +53,8 @@ function Pix(): JSX.Element {
         setName(pix.name);
         setKey(pix.key);
         setBank(pix.bank);
+        console.log(pix);
+        setOwner(pix.user);
       }
     } catch {
       setError(true);
@@ -95,7 +100,7 @@ function Pix(): JSX.Element {
     <Paper>
       {loading ? (
         <Loader />
-      ) : user?.role === "Voluntário" ? (
+      ) : user?.role === "Voluntário" || user?._id != owner ? (
         <Message error={true} message="Você não possui permissão para acessar essa página." />
       ) : !message ? (
         <Form onSubmit={handleSubmit}>

--- a/src/pages/Organizations/SocialMedia/index.tsx
+++ b/src/pages/Organizations/SocialMedia/index.tsx
@@ -12,12 +12,15 @@ import {
 } from "../../../services/socialMedia";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../../../contexts/AuthContext";
+import { OrganizationInterface } from "../../../services/users";
 
 function SocialMedia(): JSX.Element {
   const [whatsapp, setWhatsapp] = useState<string>();
   const [instagram, setInstagram] = useState<string>();
   const [facebook, setFacebook] = useState<string>();
   const [tiktok, setTiktok] = useState<string>();
+
+  const [owner, setOwner] = useState<OrganizationInterface>();
 
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
@@ -63,6 +66,7 @@ function SocialMedia(): JSX.Element {
         setFacebook(socialMedia.facebook);
         setWhatsapp(socialMedia.whatsapp);
         setTiktok(socialMedia.tiktok);
+        setOwner(socialMedia.user);
       }
     } catch {
       setError(true);
@@ -82,7 +86,7 @@ function SocialMedia(): JSX.Element {
     <Paper>
       {loading ? (
         <Loader />
-      ) : user?.role === "Voluntário" ? (
+      ) : user?.role === "Voluntário" || user?._id != owner ? (
         <Message error={true} message="Você não possui permissão para acessar essa página." />
       ) : !message ? (
         <Form onSubmit={handleSubmit}>

--- a/src/services/pix.ts
+++ b/src/services/pix.ts
@@ -15,7 +15,7 @@ export interface PixInterface {
   name: string;
   key: string;
   bank: string;
-  organization?: OrganizationInterface;
+  user?: OrganizationInterface;
 }
 
 export const createPixKey = async (payload: PixInterface) => {

--- a/src/services/socialMedia.ts
+++ b/src/services/socialMedia.ts
@@ -7,7 +7,7 @@ export interface SocialMediaInterface {
   instagram?: string;
   facebook?: string;
   tiktok?: string;
-  organization?: OrganizationInterface;
+  user?: OrganizationInterface;
 }
 
 export const createSocialMedia = async (payload: SocialMediaInterface) => {


### PR DESCRIPTION
## O que foi feito
Adicionado validação nas páginas de edição de pix e de redes sociais, para que apenas a organização dona dos dados possa visualizar o formulário.