### PR TITLE
[US15-154] Remover ToggleButton do perfil quando não há projetos para exibir

### DIFF
--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -170,9 +170,13 @@ function Profile(): JSX.Element {
                   )}
                   <HeaderLine>
                     <Text>
-                      {loggedUser?.role !== "Visitante" && loggedUser?._id === user._id
-                        ? "Seus projetos"
-                        : "Projetos"}
+                      {loggedUser?.role !== "Visitante" &&
+                        loggedUser?._id === user._id &&
+                        "Seus projetos"}
+                      {loggedUser?.role !== "Visitante" &&
+                        loggedUser?._id !== user._id &&
+                        posts?.length! > 0 &&
+                        "Projetos"}
                     </Text>
                     <Divider />
                     {loggedUser?.role !== "Visitante" && loggedUser?._id === user._id && (
@@ -186,11 +190,13 @@ function Profile(): JSX.Element {
                     )}
                   </HeaderLine>
                   <HeaderLine>
-                    <ToggleButton
-                      firstTitle="Atualizações"
-                      secondTitle="Projetos"
-                      setSelected={setSelected}
-                    />
+                    {posts?.length! > 0 && (
+                      <ToggleButton
+                        firstTitle="Atualizações"
+                        secondTitle="Projetos"
+                        setSelected={setSelected}
+                      />
+                    )}
                   </HeaderLine>
                 </>
               ) : (


### PR DESCRIPTION
## O que foi feito
Ajustado para o perfil só exibir o `ToggleButton` quando existem atualizações ou projetos para listar.